### PR TITLE
chore: Include category in preset filenames (v1.1.1)

### DIFF
--- a/injected.js
+++ b/injected.js
@@ -83,6 +83,7 @@ window.addEventListener('getPresetsListRequest', function (event) {
 // Listen for individual preset data request
 window.addEventListener('getPresetDataRequest', function (event) {
   var presetId = event.detail.id;
+  var presetCategory = event.detail.category;
 
   var formData = new FormData();
   formData.append('action', 'builder_ajax');
@@ -101,6 +102,7 @@ window.addEventListener('getPresetDataRequest', function (event) {
         window.dispatchEvent(new CustomEvent('presetDataResponse', {
           detail: {
             id: presetId,
+            category: presetCategory,
             preset: response.data[0]['preset']
           }
         }));

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "MTG Card Builder Backup",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Save and restore your MTG card designs as JSON files to continue working on them later.",
   "content_scripts": [
     {


### PR DESCRIPTION
## 🎯 Overview
Improves preset file naming by including the category as a prefix for better organization.

## ✨ Changes
- **Individual preset download**: Files now named as `{name}_{category}.json` (e.g., `blue_legendary_creature.json`)
- **Bulk ZIP download**: All presets in ZIP use the same naming convention
- **Version bump**: Updated to v1.1.1

## 📝 Example
**Before:**
- `blue_legendary.json`
- `red_common.json`

**After:**
- `blue_legendary_creature.json`
- `red_common_enchanment.json`

## 🔧 Technical Changes
- Updated `downloadSinglePreset()` to accept and use category parameter
- Updated `displayPresetsList()` to pass category via data attribute
- Updated `downloadAllPresets()` to include category in ZIP filenames
- Manifest version updated to 1.1.1

## ✅ Testing
1. Download individual preset - verify filename includes category
2. Download all as ZIP - verify all files in ZIP include category prefix
3. Verify "uncategorized" is used when no category set

## 📦 Files Changed
- `manifest.json` - Version bump to 1.1.1
- `content.js` - Updated preset download functions to include category
- `injected.js` - Updated event listeners functions to include category

## 🚀 Migration Notes
No breaking changes. Existing functionality unchanged, only filename format improved.